### PR TITLE
Push image to docker hub using the codice account.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ pipeline {
         GITHUB_USERNAME = 'codice'
         GITHUB_TOKEN = credentials('github-api-cred')
         GITHUB_REPONAME = 'codice-itest'
+        DOCKERHUB_CREDS = credentials ('dockerhub-codicebot')
     }
     stages {
         stage('Setup') {
@@ -84,9 +85,11 @@ pipeline {
                     environment name: 'JENKINS_ENV', value: 'prod'
                 }
             }
-            steps{
-                withMaven(maven: 'maven-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
-                    sh 'mvn deploy -B -DskipStatic=true -DskipTests=true -P push'
+        steps{
+                withCredentials([usernameColonPassword(credentialsId: 'dockerhub-codicebot', variable: 'DOCKERHUB_TOKEN')]) {
+                    withMaven(maven: 'maven-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
+                        sh 'mvn deploy -B -DskipStatic=true -DskipTests=true -Djib.to.auth.username=$DOCKERHUB_CREDS_USR -Djib.to.auth.password=$DOCKERHUB_CREDS_PSW -P push'
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
             }
             steps {
                 withMaven(maven: 'maven-latest', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
-                    sh 'mvn clean install'
+                    sh 'mvn clean install -P push'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
             }
             steps {
                 withMaven(maven: 'maven-latest', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
-                    sh 'mvn clean install -P push'
+                    sh 'mvn clean install'
                 }
             }
         }
@@ -86,7 +86,7 @@ pipeline {
             }
             steps{
                 withMaven(maven: 'maven-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
-                    sh 'mvn deploy -B -DskipStatic=true -DskipTests=true'
+                    sh 'mvn deploy -B -DskipStatic=true -DskipTests=true -P push'
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Below is an example `pom.xml` block which does this using the `jib` maven plugin
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
                     <from>
-                        <image>docker://codice-itest:0.0.1</image>
+                        <image>docker.io/codice/itest:0.0.1</image>
                     </from>
                     <to>
                         <image>integrationtest-example</image>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@ http://www.gnu.org/licenses/lgpl.html.
                     <artifactId>jib-maven-plugin</artifactId>
                     <configuration>
                         <from>mvn
-                            <image>alpine:3.12</image>
+                            <image>openjdk:8-jre</image>
                         </from>
                         <to>
                             <image>docker.io/codice/itest</image>

--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,8 @@ http://www.gnu.org/licenses/lgpl.html.
         <codice-itest-api.version>0.0.1</codice-itest-api.version>
         <gson.version>2.8.6</gson.version>
         <commons-lang3.version>3.11</commons-lang3.version>
-
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven.release.plugin.version>3.0.0-M1</maven.release.plugin.version>
-
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,9 @@ http://www.gnu.org/licenses/lgpl.html.
                     <groupId>com.google.cloud.tools</groupId>
                     <artifactId>jib-maven-plugin</artifactId>
                     <configuration>
+                        <from>mvn
+                            <image>alpine:3.12</image>
+                        </from>
                         <to>
                             <image>docker.io/codice/itest</image>
                             <tags>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,8 @@ See the GNU Lesser General Public License for more details. A copy of the GNU Le
 http://www.gnu.org/licenses/lgpl.html.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.codice</groupId>
@@ -85,7 +86,37 @@ http://www.gnu.org/licenses/lgpl.html.
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.google.cloud.tools</groupId>
+                    <artifactId>jib-maven-plugin</artifactId>
+                    <configuration>
+                        <to>
+                            <image>docker.io/codice/itest</image>
+                            <tags>
+                                <tag>${project.version}</tag>
+                                <tag>latest</tag>
+                            </tags>
+                        </to>
+                        <container>
+                            <extraClasspath>/app/tests/*</extraClasspath>
+                            <environment>
+                                <spring.config.location>
+                                    file:/app/tests/classes/,file:/app/tests/classes/,file:/app/config/
+                                </spring.config.location>
+                            </environment>
+                            <volumes>
+                                <path>/app/tests</path>
+                                <path>/app/config</path>
+                            </volumes>
+                        </container>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -120,29 +151,10 @@ http://www.gnu.org/licenses/lgpl.html.
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <configuration>
-                    <to>
-                        <image>codice-itest</image>
-                        <tags>
-                            <tag>${project.version}</tag>
-                            <tag>latest</tag>
-                        </tags>
-                    </to>
-                    <container>
-                        <extraClasspath>/app/tests/*</extraClasspath>
-                        <environment>
-                            <spring.config.location>file:/app/tests/classes/,file:/app/tests/classes/,file:/app/config/</spring.config.location>
-                        </environment>
-                        <volumes>
-                            <path>/app/tests</path>
-                            <path>/app/config</path>
-                        </volumes>
-                    </container>
-                </configuration>
                 <executions>
                     <execution>
                         <id>build-image</id>
-                        <phase>package</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>dockerBuild</goal>
                         </goals>
@@ -160,7 +172,36 @@ http://www.gnu.org/licenses/lgpl.html.
                     <pushChanges>false</pushChanges>
                 </configuration>
             </plugin>
-			
+
         </plugins>
     </build>
+    <repositories>
+        <repository>
+            <id>codice</id>
+            <url>https://artifacts.codice.org/content/repositories/releases/</url>
+        </repository>
+    </repositories>
+
+    <profiles>
+        <profile>
+            <id>push</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.google.cloud.tools</groupId>
+                        <artifactId>jib-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>push-image</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
The Docker image is not being pushed to Docker Hub.

This PR adds a Maven profile to do the push, and invokes that profile for the Jenkins Deploy stage.

@TonyMorrison 
Not sure how to do auth for the Docker Hob Codice account... I don't have admin access to the Codice Nexus.

The name of the image respository is change to match other codice repos (codice/itest)on Docker Hub:

![image](https://user-images.githubusercontent.com/133284/93844629-b1e03480-fc52-11ea-8527-5f56e2b882e4.png)

This change, if accepted, would need to be forward-ported.
