### PR TITLE
Update to logging strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ you implement a test:
    tests.
 3) Use the standard JUnit assertions classes to validate/verify test results.
 
-###### *See the example code in `../codice-itest-example`
-
 ##### Docker Image
 Tests are executed using the `codice-itest` Docker image which is built as part of `mvn clean install`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@ http://www.gnu.org/licenses/lgpl.html.
 
     <groupId>org.codice</groupId>
     <artifactId>codice-itest</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>0.1.1</version>
 
     <properties>
         <spring.version>5.2.8.RELEASE</spring.version>

--- a/src/main/java/org/codice/itest/reporter/LoggingDiagnosticTestReporter.java
+++ b/src/main/java/org/codice/itest/reporter/LoggingDiagnosticTestReporter.java
@@ -31,8 +31,9 @@ final class LoggingDiagnosticTestReporter implements Consumer<TestResult> {
         String formattedResult = testResultFormatter.apply(testResult);
 
         switch (testResult.getTestStatus()) {
-            case PASS:
-            case FAIL: logger.info(formattedResult);
+            case PASS: logger.info(formattedResult);
+                break;
+            case FAIL: logger.warn(formattedResult);
                 break;
             case ERROR: logger.error(formattedResult);
         }

--- a/src/main/java/org/codice/itest/result/TestResultFactoryImpl.java
+++ b/src/main/java/org/codice/itest/result/TestResultFactoryImpl.java
@@ -15,12 +15,20 @@ import java.util.UUID;
 
 import org.codice.itest.api.TestResult;
 import org.codice.itest.api.TestResultFactory;
+import org.codice.itest.api.TestStatus;
+import org.slf4j.MDC;
 
 /**
  * Implements TestResultFactory to create appropriate instances of the TestResult interface to the
  * main application.
  */
 final class TestResultFactoryImpl implements TestResultFactory {
+    private static final String TEST_NAME = "testName";
+    private static final String START_TIME = "startTime";
+    private static final String END_TIME = "endTime";
+    private static final String EXCEPTION_MESSAGE = "exceptionMessage";
+    private static final String THROWABLE = "throwable";
+    private static final String TEST_STATUS = "testStatus";
     private UUID runId;
 
     /**
@@ -32,16 +40,31 @@ final class TestResultFactoryImpl implements TestResultFactory {
 
     @Override
     public TestResult pass(String testName, Instant startTime, Instant endTime) {
+        logTestResultCommonFields(testName, startTime, endTime);
+        MDC.put(TEST_STATUS, TestStatus.PASS.name());
         return new PassTestResultImpl(runId, testName,startTime, endTime);
     }
 
     @Override
     public TestResult fail(String testName, String exceptionMessage, Instant startTime, Instant endTime) {
+        logTestResultCommonFields(testName, startTime, endTime);
+        MDC.put(EXCEPTION_MESSAGE, exceptionMessage);
+        MDC.put(TEST_STATUS, TestStatus.FAIL.name());
         return new FailureTestResultImpl(runId, testName, exceptionMessage,startTime, endTime);
     }
 
     @Override
     public TestResult error(String testName, Throwable throwable, Instant startTime, Instant endTime) {
+        logTestResultCommonFields(testName, startTime, endTime);
+        MDC.put(THROWABLE, throwable.toString());
+        MDC.put(TEST_STATUS, TestStatus.ERROR.name());
         return new ErrorTestResultImpl(runId, testName, throwable,startTime, endTime);
+    }
+
+    private void logTestResultCommonFields(String testName, Instant startTime, Instant endTime) {
+        MDC.clear();
+        MDC.put(TEST_NAME, testName);
+        MDC.put(START_TIME, startTime.toString());
+        MDC.put(END_TIME, endTime.toString());
     }
 }


### PR DESCRIPTION
Updated the logging strategy to include test result information that will be accessible within the logback.xml file. Also removed one misleading line from the `README.md`