### PR TITLE
Return non-zero exit code on itests failure or error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@ http://www.gnu.org/licenses/lgpl.html.
 
     <groupId>org.codice</groupId>
     <artifactId>codice-itest</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
 
     <properties>
         <spring.version>5.2.8.RELEASE</spring.version>
@@ -89,7 +89,7 @@ http://www.gnu.org/licenses/lgpl.html.
                     <groupId>com.google.cloud.tools</groupId>
                     <artifactId>jib-maven-plugin</artifactId>
                     <configuration>
-                        <from>mvn
+                        <from>
                             <image>openjdk:8-jre</image>
                         </from>
                         <to>

--- a/src/main/java/org/codice/itest/IntegrationTestApplication.java
+++ b/src/main/java/org/codice/itest/IntegrationTestApplication.java
@@ -10,14 +10,29 @@
  */
 package org.codice.itest;
 
+import org.codice.itest.reporter.ExitCodeReporter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ExitCodeGenerator;
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 
+
+
 @SpringBootApplication
 @ComponentScan(basePackages = {"org.codice", "${itest.packagescan:org.codice}"})
-public class IntegrationTestApplication {
+public class IntegrationTestApplication implements ExitCodeGenerator {
+
+    @Autowired
+    private ExitCodeReporter exitCodeReporter;
 
     public static void main(String... args) {
-        org.springframework.boot.SpringApplication.run(IntegrationTestApplication.class);
+        System.exit(SpringApplication.exit(SpringApplication.run(IntegrationTestApplication.class, args)));
     }
+
+    @Override
+    public int getExitCode() {
+        return exitCodeReporter.getExitCode();
+    }
+
 }

--- a/src/main/java/org/codice/itest/reporter/ExitCodeReporter.java
+++ b/src/main/java/org/codice/itest/reporter/ExitCodeReporter.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Codice Foundation
+
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or any later version.
+
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * http://www.gnu.org/licenses/lgpl.html.
+ */
+package org.codice.itest.reporter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codice.itest.api.TestStatus;
+
+public class ExitCodeReporter {
+
+    private final Map<TestStatus, Integer> exitCodes = new HashMap<TestStatus, Integer>() {{
+        put(TestStatus.ERROR, 2);
+        put(TestStatus.FAIL, 1);
+        put(TestStatus.PASS, 0);
+    }};
+
+    private List<Integer> exitCodeMappings = new ArrayList<>();
+
+    public void register(TestStatus testStatus) {
+        exitCodeMappings.add(exitCodes.get(testStatus));
+    }
+
+    public int getExitCode() {
+        return Collections.max(exitCodeMappings);
+    }
+
+}

--- a/src/main/java/org/codice/itest/reporter/LoggingDiagnosticTestReporter.java
+++ b/src/main/java/org/codice/itest/reporter/LoggingDiagnosticTestReporter.java
@@ -17,13 +17,17 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 final class LoggingDiagnosticTestReporter implements Consumer<TestResult> {
+
     private Logger logger;
+
+    private ExitCodeReporter exitCodeReporter;
 
     private Function<TestResult, String> testResultFormatter;
 
-    public LoggingDiagnosticTestReporter(Logger logger,
+    public LoggingDiagnosticTestReporter(Logger logger, ExitCodeReporter exitCodeReporter,
                                          Function<TestResult, String> testResultFormatter) {
         this.logger = logger;
+        this.exitCodeReporter = exitCodeReporter;
         this.testResultFormatter = testResultFormatter;
     }
 
@@ -37,5 +41,6 @@ final class LoggingDiagnosticTestReporter implements Consumer<TestResult> {
                 break;
             case ERROR: logger.error(formattedResult);
         }
+        exitCodeReporter.register(testResult.getTestStatus());
     }
 }

--- a/src/main/java/org/codice/itest/reporter/RestDiagnosticTestReporter.java
+++ b/src/main/java/org/codice/itest/reporter/RestDiagnosticTestReporter.java
@@ -32,11 +32,15 @@ public final class RestDiagnosticTestReporter implements Consumer<TestResult> {
 
     private Function<TestResult, String> testResultFormatter;
 
+    private ExitCodeReporter exitCodeReporter;
+
     private Logger logger = LoggerFactory.getLogger(RestDiagnosticTestReporter.class);
 
-    public RestDiagnosticTestReporter(RestTemplate restTemplate, String logstashUrl, Function<TestResult, String> testResultFormatter) {
+    public RestDiagnosticTestReporter(RestTemplate restTemplate, String logstashUrl,
+            ExitCodeReporter exitCodeReporter, Function<TestResult, String> testResultFormatter) {
         this.restTemplate = restTemplate;
         this.logstashUrl = logstashUrl;
+        this.exitCodeReporter = exitCodeReporter;
         this.testResultFormatter = testResultFormatter;
     }
 
@@ -57,5 +61,6 @@ public final class RestDiagnosticTestReporter implements Consumer<TestResult> {
                     response);
             logger.error(error);
         }
+        exitCodeReporter.register(testResult.getTestStatus());
     }
 }

--- a/src/main/java/org/codice/itest/reporter/TestReporterConfiguration.java
+++ b/src/main/java/org/codice/itest/reporter/TestReporterConfiguration.java
@@ -46,23 +46,28 @@ public class TestReporterConfiguration {
         return new SlackFormatter();
     }
 
+    @Bean
+    public ExitCodeReporter exitCodeReporter(){
+        return new ExitCodeReporter();
+    }
+
     @Bean("testReporter")
     @ConditionalOnProperty(prefix="itest.reporter", name="logger")
     public Consumer<TestResult> loggingDiagnosticTestReporter() {
         Logger logger = LoggerFactory.getLogger(loggerName);
-        return new LoggingDiagnosticTestReporter(logger, toStringFormatter());
+        return new LoggingDiagnosticTestReporter(logger, exitCodeReporter(), toStringFormatter());
     }
 
     @Bean("testReporter")
     @ConditionalOnMissingBean
     public Consumer<TestResult> defaultLoggingDiagnosticTestReporter() {
         Logger logger = LoggerFactory.getLogger(LoggingDiagnosticTestReporter.class);
-        return new LoggingDiagnosticTestReporter(logger, toStringFormatter());
+        return new LoggingDiagnosticTestReporter(logger, exitCodeReporter(), toStringFormatter());
     }
 
     @Bean
     @ConditionalOnProperty(prefix="itest.reporter", name="url")
     public Consumer<TestResult> restDiagnosticTestReporter() {
-        return new RestDiagnosticTestReporter(restTemplate(), logstashUrl, slackFormatter());
+        return new RestDiagnosticTestReporter(restTemplate(), logstashUrl, exitCodeReporter(), slackFormatter());
     }
 }


### PR DESCRIPTION
The codice-itest will now return its worst-case status code. 
If any tests report an error, the return code will be 2.
If there is a comination of pass/fail, the return code will be 1.
If all pass, the return code will be 0.