### PR TITLE
Make timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ other. Default is a randomly-chosen value.
 `LoggingIntegrationTestReporter` logger will be used.
 * `itest.reporter.url` - the url of an endpoint to send test results to. By default, no attempt will
 be made send test results to any endpoint.
+* `itest.max.execution.minutes` - the maximum number of minutes tests will run for. Default is 10.
 
 ##### Implementing Tests
 In this framework, tests are POJOs. Each class is a single test. Common code can reside in a parent class. Here's how 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@ http://www.gnu.org/licenses/lgpl.html.
 
     <groupId>org.codice</groupId>
     <artifactId>codice-itest</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.4-SNAPSHOT</version>
 
     <properties>
         <spring.version>5.2.8.RELEASE</spring.version>

--- a/src/main/java/org/codice/itest/IntegrationTestService.java
+++ b/src/main/java/org/codice/itest/IntegrationTestService.java
@@ -13,6 +13,7 @@ package org.codice.itest;
 import org.codice.itest.api.IntegrationTest;
 import org.codice.itest.api.TestResult;
 import org.codice.itest.api.TestResultFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
@@ -43,6 +44,9 @@ final class IntegrationTestService implements CommandLineRunner {
 
     private TestResultFactory testResultFactory;
 
+    @Value("${itest.max.execution.minutes:#{10}}")
+    private int maxExecutionMinutes;
+
     /**
      *
      * @param tests - The set of all DiagnosticTest objects found in the Spring application context.
@@ -69,6 +73,6 @@ final class IntegrationTestService implements CommandLineRunner {
         this.tests.forEach(test -> executorService.execute(new TestExecutorTask(test,
                 testResultListenerList, testResultFactory)));
         executorService.shutdown();
-        executorService.awaitTermination(120, TimeUnit.SECONDS);
+        executorService.awaitTermination(maxExecutionMinutes, TimeUnit.MINUTES);
     }
 }


### PR DESCRIPTION
When there were multiple test suites, not all of the tests would finish running before it timed out. 
+ Increased the default time tests can be run in, and made it configurable