### PR TITLE
Change how test result logs are formatted

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ other. Default is a randomly-chosen value.
 `LoggingIntegrationTestReporter` logger will be used.
 * `itest.reporter.url` - the url of an endpoint to send test results to. By default, no attempt will
 be made send test results to any endpoint.
+* `itest.max.execution.minutes` - the maximum number of minutes tests will run for. Default is 10.
 
 ##### Implementing Tests
 In this framework, tests are POJOs. Each class is a single test. Common code can reside in a parent class. Here's how 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@ http://www.gnu.org/licenses/lgpl.html.
 
     <groupId>org.codice</groupId>
     <artifactId>codice-itest</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.4-SNAPSHOT</version>
 
     <properties>
         <spring.version>5.2.8.RELEASE</spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@ http://www.gnu.org/licenses/lgpl.html.
 
     <groupId>org.codice</groupId>
     <artifactId>codice-itest</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.5-SNAPSHOT</version>
 
     <properties>
         <spring.version>5.2.8.RELEASE</spring.version>

--- a/src/main/java/org/codice/itest/IntegrationTestService.java
+++ b/src/main/java/org/codice/itest/IntegrationTestService.java
@@ -13,6 +13,7 @@ package org.codice.itest;
 import org.codice.itest.api.IntegrationTest;
 import org.codice.itest.api.TestResult;
 import org.codice.itest.api.TestResultFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
@@ -43,6 +44,9 @@ final class IntegrationTestService implements CommandLineRunner {
 
     private TestResultFactory testResultFactory;
 
+    @Value("${itest.max.execution.minutes:#{10}}")
+    private int maxExecutionMinutes;
+
     /**
      *
      * @param tests - The set of all DiagnosticTest objects found in the Spring application context.
@@ -69,6 +73,6 @@ final class IntegrationTestService implements CommandLineRunner {
         this.tests.forEach(test -> executorService.execute(new TestExecutorTask(test,
                 testResultListenerList, testResultFactory)));
         executorService.shutdown();
-        executorService.awaitTermination(120, TimeUnit.SECONDS);
+        executorService.awaitTermination(maxExecutionMinutes, TimeUnit.MINUTES);
     }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="Console"
+              class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %X{startTime} %X{testName}: %highlight(%X{testStatus}) %X{exceptionMessage} %X{throwable}%ex%n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <logger name="org.codice" level="INFO"/>
+
+    <root level="OFF">
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Added `logback-spring.xml` which formats the log messages. This makes it easier for soaesb's `slack-alerter.py` to parse test results. 

Before:
![Screen Shot 2021-04-27 at 5 04 31 PM](https://user-images.githubusercontent.com/22902222/116327012-a7eb5a80-a77a-11eb-9e45-77b50cb6ee9c.png)

After:
![Screen Shot 2021-04-27 at 4 57 16 PM](https://user-images.githubusercontent.com/22902222/116326958-94d88a80-a77a-11eb-99bc-3e66bba91e0b.png)