### PR TITLE
Change test result logging format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@ http://www.gnu.org/licenses/lgpl.html.
 
     <groupId>org.codice</groupId>
     <artifactId>codice-itest</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.5-SNAPSHOT</version>
 
     <properties>
         <spring.version>5.2.8.RELEASE</spring.version>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="Console"
+              class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %X{startTime} %X{testName}: %highlight(%X{testStatus}) %X{exceptionMessage} %X{throwable}%ex%n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <logger name="org.codice" level="INFO"/>
+
+    <root level="OFF">
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
               class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>
-                %X{startTime} %X{testName}: %highlight(%X{testStatus}) %X{exceptionMessage} %X{throwable}%ex%n
+                %X{startTime} %class{0}#%X{testName}: %highlight(%X{testStatus}) %X{exceptionMessage} %X{throwable}%ex%n
             </Pattern>
         </layout>
     </appender>


### PR DESCRIPTION
Added `logback-spring.xml` which formats the log messages. This makes it easier for soaesb's `slack-alerter.py` to parse test results. 

Before:
![Screen Shot 2021-04-27 at 5 04 31 PM](https://user-images.githubusercontent.com/22902222/116327012-a7eb5a80-a77a-11eb-9e45-77b50cb6ee9c.png)

After:
![Screen Shot 2021-04-27 at 4 57 16 PM](https://user-images.githubusercontent.com/22902222/116326958-94d88a80-a77a-11eb-99bc-3e66bba91e0b.png)