### PR TITLE
Adds a stacktrace to failures and errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,11 @@ http://www.gnu.org/licenses/lgpl.html.
 
     <groupId>org.codice</groupId>
     <artifactId>codice-itest</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <properties>
         <spring.version>5.2.8.RELEASE</spring.version>
-        <codice-itest-api.version>1.0.1</codice-itest-api.version>
+        <codice-itest-api.version>2.0.0-SNAPSHOT</codice-itest-api.version>
         <gson.version>2.8.6</gson.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>

--- a/src/main/java/org/codice/itest/TestExecutorTask.java
+++ b/src/main/java/org/codice/itest/TestExecutorTask.java
@@ -22,11 +22,11 @@ import java.util.function.Consumer;
  * A sub-class of Runnable that handles the actual execution of each test.
  */
 final class TestExecutorTask implements Runnable {
-    private IntegrationTest diagnosticTest;
+    private final IntegrationTest diagnosticTest;
 
-    private List<Consumer<TestResult>> testResultListenerList;
+    private final List<Consumer<TestResult>> testResultListenerList;
 
-    private TestResultFactory testResultFactory;
+    private final TestResultFactory testResultFactory;
 
     /**
      * @param diagnosticTest - An instance of DiagnosticTest that is ready to be executed.
@@ -53,14 +53,13 @@ final class TestExecutorTask implements Runnable {
             diagnosticTest.cleanup();
             this.notify(testResultFactory.pass(testName, beforeTest, Instant.now()));
         } catch (AssertionError e) {
-            this.notify(testResultFactory.fail(testName, e.getMessage(), beforeTest, Instant.now()));
+            this.notify(testResultFactory.fail(testName, e, beforeTest, Instant.now()));
         } catch (Throwable t) {
             this.notify(testResultFactory.error(testName, t, beforeTest, Instant.now()));
         }
     }
 
     private void notify(TestResult testResult) {
-        testResultListenerList.stream()
-                .forEach(l -> l.accept(testResult));
+        testResultListenerList.forEach(l -> l.accept(testResult));
     }
 }

--- a/src/main/java/org/codice/itest/result/ErrorTestResultImpl.java
+++ b/src/main/java/org/codice/itest/result/ErrorTestResultImpl.java
@@ -20,7 +20,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.codice.itest.api.TestStatus;
 
 final class ErrorTestResultImpl extends BaseTestResult {
-    private String stackTrace;
+    private final String stackTrace;
 
     public ErrorTestResultImpl(UUID runId, String testName, Throwable throwable, Instant startTime, Instant endTime) {
         super(runId, testName, TestStatus.ERROR, startTime,endTime);

--- a/src/main/java/org/codice/itest/result/FailureTestResultImpl.java
+++ b/src/main/java/org/codice/itest/result/FailureTestResultImpl.java
@@ -19,11 +19,13 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.codice.itest.api.TestStatus;
 
 final class FailureTestResultImpl extends BaseTestResult {
-    private String failMessage;
+    private final String failMessage;
+    private final String stackTrace;
 
-    FailureTestResultImpl(UUID runId, String testName, String failMessage, Instant startTime, Instant endTime) {
+    FailureTestResultImpl(UUID runId, String testName, String failMessage, String stackTrace, Instant startTime, Instant endTime) {
         super(runId, testName, TestStatus.FAIL, startTime,endTime);
         this.failMessage = failMessage;
+        this.stackTrace = stackTrace;
     }
 
     @Override
@@ -32,6 +34,7 @@ final class FailureTestResultImpl extends BaseTestResult {
                 .append(super.getTestStatus())
                 .append(super.getTestName())
                 .append(this.getFailMessage())
+                .append(this.getStackTrace())
                 .append(super.getStartTime())
                 .append(this.getDuration())
                 .toString();
@@ -55,7 +58,8 @@ final class FailureTestResultImpl extends BaseTestResult {
 
         return new EqualsBuilder().append(super.getRunId(), testResult.getRunId())
                 .append(super.getTestName(), testResult.getTestName())
-                .append(this.getFailMessage(), testResult.failMessage)
+                .append(this.getFailMessage(), testResult.getFailMessage())
+                .append(this.getStackTrace(), testResult. getStackTrace())
                 .append(super.getTestStatus(), testResult.getTestStatus())
                 .append(this.getStartTime(), testResult.getStartTime())
                 .append(this.getDuration(), testResult.getDuration())
@@ -68,6 +72,7 @@ final class FailureTestResultImpl extends BaseTestResult {
                 .append(super.getTestName())
                 .append(super.getTestStatus())
                 .append(this.getFailMessage())
+                .append(this.getStackTrace())
                 .append(this.getStartTime())
                 .append(this.getDuration())
                 .build();
@@ -76,4 +81,6 @@ final class FailureTestResultImpl extends BaseTestResult {
     public String getFailMessage() {
         return this.failMessage;
     }
+
+    private String getStackTrace() { return stackTrace; }
 }


### PR DESCRIPTION
Some minor fixes, renames `throwable` to `stacktrace` in the error scenario, and adds a stacktrace to failure scenarios.

Depends on API bump: https://github.com/codice/codice-itest-api/pull/3