### PR TITLE
Update TestExecutorTask to always perform test cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ will be executed in the order given. If not provided all tests beans will be exe
 * `itest.result.runId` - A UUID that allows the caller to associate a group of tests with each 
 other. Default is a randomly-chosen value.
 * `itest.reporter.logger` - the name of a logger to report test results to. If not supplied then 
-`LoggingIntegrationTestReporter` logger will be used.
+`LoggingDiagnosticTestReporter` logger will be used.
 * `itest.reporter.url` - the url of an endpoint to send test results to. By default, no attempt will
 be made send test results to any endpoint.
 * `itest.max.execution.minutes` - the maximum number of minutes tests will run for. Default is 10.

--- a/src/main/java/org/codice/itest/TestExecutorTask.java
+++ b/src/main/java/org/codice/itest/TestExecutorTask.java
@@ -50,16 +50,22 @@ final class TestExecutorTask implements Runnable {
         try {
             diagnosticTest.setup();
             diagnosticTest.test();
-            diagnosticTest.cleanup();
             this.notify(testResultFactory.pass(testName, beforeTest, Instant.now()));
         } catch (AssertionError e) {
             this.notify(testResultFactory.fail(testName, e, beforeTest, Instant.now()));
         } catch (Throwable t) {
             this.notify(testResultFactory.error(testName, t, beforeTest, Instant.now()));
         }
+        finally {
+            try {
+                diagnosticTest.cleanup();
+            } catch (Exception e) {
+                this.notify(testResultFactory.error(testName, e, beforeTest, Instant.now()));
+            }
+        }
     }
 
     private void notify(TestResult testResult) {
-        testResultListenerList.forEach(l -> l.accept(testResult));
+        testResultListenerList.forEach(listener -> listener.accept(testResult));
     }
 }


### PR DESCRIPTION
Reverting some of the behavior introduced in https://github.com/codice/codice-itest/pull/8